### PR TITLE
ignore vite timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "node server",
-    "dev": "nodemon server",
+    "dev": "nodemon server --ignore 'vite.config.js.**'",
     "preview": "NODE_ENV=staging npm run build && node server",
     "build": "run-s build:client build:server",
     "build:client": "vite build",


### PR DESCRIPTION
When I ran `npm run dev` , the server kept restarting over and over. I think the reason was because `vite` creates config file automatically and nodemon listens to any file changes and this goes into an infinite server restarts. 

All I did in this PR is ignore that file in the `package.json`.